### PR TITLE
Fix case sensitivity in search function

### DIFF
--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -20,9 +20,10 @@ class SearchForm extends Component {
   handleSubmit = (e) => {
     this.setState({ classes: 'no-results hidden' })
     e.preventDefault();
-    let searchTerm = this.state.searchTerm;
-    let results = this.props.cards.filter(card => card.name.includes(searchTerm) || card.meaning_up.includes(searchTerm)
+    let searchTerm = this.state.searchTerm.toUpperCase();
+    let results = this.props.cards.filter(card => card.name.toUpperCase().includes(searchTerm) || card.meaning_up.toUpperCase().includes(searchTerm)
     );
+
     if(results.length) {
       this.props.search(results);
       this.setState({ searchTerm: '' })


### PR DESCRIPTION
### Type of change made:
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Description:
Search now transforms both strings to uppercase to prevent case-sensitive search

### Were there any challenges that arose while implementing this feature? If so, how were they addressed?
N/A

### Other Notes:
Search still includes substring matches and partial-word matches. This does not fix that issue.

### Related Issues:
Closes #5 

### Files modified (list below):
-  src/components/SearchForm/SearchForm.js